### PR TITLE
Add rotating status with stats

### DIFF
--- a/cogs/general/rotating_status.py
+++ b/cogs/general/rotating_status.py
@@ -1,0 +1,34 @@
+import discord
+from discord.ext import commands, tasks
+from handlers.config import mac_load_bans
+
+class RotatingStatus(commands.Cog):
+    def __init__(self, bot: commands.Bot):
+        self.bot = bot
+        self.update_status.start()
+
+    def cog_unload(self):
+        self.update_status.cancel()
+
+    @tasks.loop(seconds=30)
+    async def update_status(self):
+        bans = mac_load_bans()
+        banned_count = len(bans) if bans else 0
+        statuses = [
+            f"\U0001F6AB {banned_count} globally banned",
+            f"\U0001F465 Managing {len(self.bot.users)} users",
+            f"\U0001F6E1\uFE0F On {len(self.bot.guilds)} servers",
+        ]
+        message = statuses[self.update_status.current_loop % len(statuses)]
+        try:
+            await self.bot.change_presence(activity=discord.Game(name=message))
+        except Exception:
+            pass
+
+    @update_status.before_loop
+    async def before_update_status(self):
+        await self.bot.wait_until_ready()
+
+
+def setup(bot: commands.Bot):
+    bot.add_cog(RotatingStatus(bot))

--- a/main.py
+++ b/main.py
@@ -126,7 +126,6 @@ async def on_ready():
     print(Fore.WHITE + f"Logged in as {bot.user} (ID: {bot.user.id})")
     print(Fore.CYAN + "-"*45)
 
-    await bot.change_presence(activity=discord.Game(name="with your mom"))
 
 #=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 # Extension Loader


### PR DESCRIPTION
## Summary
- add rotating status cog to update presence every 30s
- remove old presence line in `on_ready`

## Testing
- `python3 -m py_compile main.py cogs/general/rotating_status.py`
- `pip install -r requirements.txt` *(fails: no matching distribution for `io`)*

------
https://chatgpt.com/codex/tasks/task_e_686cd39e79088333a4466202b5b289e8