### PR TITLE
Fix import by switching to py-cord

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 ## 📍 Overview
 
 **Maggibot** is a modular Discord bot written in Python using
-[`discord.py`](https://github.com/Rapptz/discord.py). It is designed to be
+[`py-cord`](https://github.com/Pycord-Development/pycord). It is designed to be
 extended through cogs and provides a wide range of moderation and community
 management tools. The bot relies on a small set of configuration and data files
 (see [`handlers/config.py`](handlers/config.py)) and can be customised via an

--- a/cogs/general/info.py
+++ b/cogs/general/info.py
@@ -184,7 +184,7 @@ class InfoSystem(commands.Cog):
             name="⚙️ Technical Specifications",
             value=f"```yaml\n"
                   f"Python: {platform.python_version()}\n"
-                  f"discord.py: {discord.__version__}\n"
+                  f"Pycord: {discord.__version__}\n"
                   f"OS: {platform.system()} {platform.release()}```",
             inline=False
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp
 colorthief
 colorama
-discord.py==2.5.2
+py-cord==2.6.1
 Pillow
 python-dateutil
 python-dotenv


### PR DESCRIPTION
## Summary
- update to py-cord dependency to restore `discord.commands`
- mention py-cord in README
- update version label in status embed

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e80182ad08333ac8277ffe642f25b