### PR TITLE
Fix timestamp call in ticket transcript

### DIFF
--- a/cogs/ticket/ticketsystem.py
+++ b/cogs/ticket/ticketsystem.py
@@ -156,7 +156,7 @@ class TicketSystem(Cog):
             "<div class='container'>",
             f"<div class='header'>",
             f"<h2>#{html.escape(thread.name)}</h2>",
-            f"<div class='info'>Transcript generated on {datetime.now().strftime('%B %d, %Y at %I:%M %p')}</div>",
+            f"<div class='info'>Transcript generated on {datetime.datetime.now().strftime('%B %d, %Y at %I:%M %p')}</div>",
             f"</div>",
             "<div class='messages'>",
         ]


### PR DESCRIPTION
## Summary
- use `datetime.datetime.now()` when using `import datetime`

## Testing
- `python -m pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687d4fdadf5083339717f5b942cde6f6