### PR TITLE
Fix embed color formatting in ticket transcript

### DIFF
--- a/cogs/ticket/ticketsystem.py
+++ b/cogs/ticket/ticketsystem.py
@@ -223,7 +223,9 @@ class TicketSystem(Cog):
             # Embeds
             if message.embeds:
                 for embed in message.embeds:
-                    embed_color = f"#{embed.color:06x}" if embed.color else "#5865f2"
+                    embed_color = (
+                        f"#{embed.color.value:06x}" if embed.color else "#5865f2"
+                    )
                     lines.append(f"<div class='embed' style='border-left-color: {embed_color};'>")
                     
                     # Embed author


### PR DESCRIPTION
## Summary
- use `embed.color.value` to convert color to hex string in ticket transcripts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d51683290833392a4b6daecea7caf