### PR TITLE
Improve logging functionality

### DIFF
--- a/cogs/logging/logging.py
+++ b/cogs/logging/logging.py
@@ -39,12 +39,19 @@ class Logging(commands.Cog):
     # ------------------------------------------------------------
     # Helper to send logs
     # ------------------------------------------------------------
-    async def post_log(self, guild: discord.Guild, embed: discord.Embed, title: str):
+    async def post_log(
+        self,
+        guild: discord.Guild,
+        embed: discord.Embed,
+        title: str,
+        user_id: int | None = None,
+    ):
         forum = config.get_logging_forum(guild)
         if not forum or not isinstance(forum, discord.ForumChannel):
             return
         try:
-            await forum.create_thread(name=title, embed=embed)
+            thread_name = f"{title}-{user_id}" if user_id else title
+            await forum.create_thread(name=thread_name, embed=embed)
         except Exception as e:
             LogError(f"Failed to post log in guild {guild.id}: {e}")
 
@@ -53,40 +60,140 @@ class Logging(commands.Cog):
     # ------------------------------------------------------------
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member):
-        description = (
-            f"{member.mention} joined the server.\n"
-            f"Account created: <t:{int(member.created_at.timestamp())}:R>"
+        description = f"{member.mention} joined the server."
+        fields = [
+            ("Account Created", f"<t:{int(member.created_at.timestamp())}:R>", True),
+            ("User ID", str(member.id), True),
+        ]
+        embed = create_log_embed(
+            "Member Joined",
+            description,
+            "join",
+            member,
+            fields,
         )
-        embed = create_log_embed("Member Joined", description, "join", member)
-        await self.post_log(member.guild, embed, "member-join")
+        await self.post_log(member.guild, embed, "member-join", member.id)
 
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):
-        description = (
-            f"{member.mention} left the server.\n"
-            f"Joined: <t:{int(member.joined_at.timestamp())}:R>" if member.joined_at else ""
+        description = f"{member.mention} left the server."
+        join_time = (
+            f"<t:{int(member.joined_at.timestamp())}:R>" if member.joined_at else "Unknown"
         )
-        embed = create_log_embed("Member Left", description, "leave", member)
-        await self.post_log(member.guild, embed, "member-leave")
+        fields = [
+            ("Joined", join_time, True),
+            ("User ID", str(member.id), True),
+        ]
+        embed = create_log_embed(
+            "Member Left",
+            description,
+            "leave",
+            member,
+            fields,
+        )
+        await self.post_log(member.guild, embed, "member-leave", member.id)
 
     @commands.Cog.listener()
     async def on_member_ban(self, guild: discord.Guild, user: discord.User):
         description = f"{user.mention} was banned."
-        embed = create_log_embed("Member Banned", description, "ban", user)
-        await self.post_log(guild, embed, "ban")
+        fields = [("User ID", str(user.id), True)]
+        embed = create_log_embed("Member Banned", description, "ban", user, fields)
+        await self.post_log(guild, embed, "ban", user.id)
 
     @commands.Cog.listener()
     async def on_message_delete(self, message: discord.Message):
         if not message.guild or message.author.bot:
             return
         content = message.content or "*No text content*"
-        description = (
-            f"Author: {message.author.mention}\n"
-            f"Channel: {message.channel.mention}\n"
-            f"Content: {content}"
+        description = f"Message deleted in {message.channel.mention}."
+        fields = [
+            ("Author", message.author.mention, True),
+            ("Content", content, False),
+            ("Message ID", str(message.id), True),
+            ("User ID", str(message.author.id), True),
+        ]
+        embed = create_log_embed(
+            "Message Deleted",
+            description,
+            "message_delete",
+            message.author,
+            fields,
         )
-        embed = create_log_embed("Message Deleted", description, "message_delete", message.author)
-        await self.post_log(message.guild, embed, "message-delete")
+        await self.post_log(message.guild, embed, "message-delete", message.author.id)
+
+    @commands.Cog.listener()
+    async def on_message_edit(self, before: discord.Message, after: discord.Message):
+        if not after.guild or after.author.bot:
+            return
+        if before.content == after.content:
+            return
+        description = f"Message edited in {after.channel.mention}."
+        fields = [
+            ("Author", after.author.mention, True),
+            ("Before", before.content or "*No text*", False),
+            ("After", after.content or "*No text*", False),
+            ("Message ID", str(after.id), True),
+            ("User ID", str(after.author.id), True),
+        ]
+        embed = create_log_embed(
+            "Message Edited",
+            description,
+            "message_delete",
+            after.author,
+            fields,
+        )
+        await self.post_log(after.guild, embed, "message-edit", after.author.id)
+
+    @commands.Cog.listener()
+    async def on_member_unban(self, guild: discord.Guild, user: discord.User):
+        description = f"{user.mention} was unbanned."
+        fields = [("User ID", str(user.id), True)]
+        embed = create_log_embed("Member Unbanned", description, "ban", user, fields)
+        await self.post_log(guild, embed, "unban", user.id)
+
+    @commands.Cog.listener()
+    async def on_member_update(self, before: discord.Member, after: discord.Member):
+        if before.nick != after.nick:
+            description = f"Nickname changed for {after.mention}"
+            fields = [
+                ("Before", before.nick or before.name, True),
+                ("After", after.nick or after.name, True),
+                ("User ID", str(after.id), True),
+            ]
+            embed = create_log_embed(
+                "Nickname Updated",
+                description,
+                "default",
+                after,
+                fields,
+            )
+            await self.post_log(after.guild, embed, "nickname-update", after.id)
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(self, member: discord.Member, before: discord.VoiceState, after: discord.VoiceState):
+        if before.channel != after.channel:
+            if before.channel is None:
+                action = "joined"
+                channel = after.channel
+            elif after.channel is None:
+                action = "left"
+                channel = before.channel
+            else:
+                action = "moved"
+                channel = after.channel
+
+            description = f"{member.mention} {action} voice channel {channel.mention if channel else 'N/A'}."
+            fields = [
+                ("User ID", str(member.id), True),
+            ]
+            embed = create_log_embed(
+                "Voice Channel Update",
+                description,
+                "default",
+                member,
+                fields,
+            )
+            await self.post_log(member.guild, embed, "voice-update", member.id)
 
 
 def setup(bot: commands.Bot):

--- a/extensions/loggingextension.py
+++ b/extensions/loggingextension.py
@@ -13,14 +13,42 @@ COLOR_MAP = {
 }
 
 
-def create_log_embed(title: str, description: str, color_type: str = "default", user: discord.abc.User | None = None) -> discord.Embed:
+def create_log_embed(
+    title: str,
+    description: str,
+    color_type: str = "default",
+    user: discord.abc.User | None = None,
+    fields: list[tuple[str, str, bool]] | None = None,
+) -> discord.Embed:
+    """Create a standardized log embed.
+
+    Parameters
+    ----------
+    title: str
+        Title of the embed.
+    description: str
+        Description text.
+    color_type: str, optional
+        Key for ``COLOR_MAP``.
+    user: discord.abc.User | None, optional
+        User associated with the event.
+    fields: list[tuple[str, str, bool]] | None, optional
+        Extra fields to append. Each entry is ``(name, value, inline)``.
+    """
+
     embed = discord.Embed(
         title=title,
         description=description,
         color=COLOR_MAP.get(color_type, COLOR_MAP["default"]),
         timestamp=datetime.datetime.utcnow(),
     )
+
     if user:
         embed.set_author(name=str(user), icon_url=user.display_avatar.url)
+
+    if fields:
+        for name, value, inline in fields:
+            embed.add_field(name=name, value=value, inline=inline)
+
     embed.set_footer(text="Logging System")
     return embed


### PR DESCRIPTION
## Summary
- extend `create_log_embed` to support extra fields
- include user IDs in log thread names
- add more detailed embed info for member joins/leaves, bans and deleted messages
- log additional events: message edits, unbans, nickname changes and voice state updates

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d5627bc5c8333b0fd305be6db6602