### PR TITLE
Improve logging coverage

### DIFF
--- a/extensions/loggingextension.py
+++ b/extensions/loggingextension.py
@@ -35,6 +35,11 @@ def create_log_embed(
         User associated with the event.
     fields: list[tuple[str, str, bool]] | None, optional
         Extra fields to append. Each entry is ``(name, value, inline)``.
+
+    Notes
+    -----
+    The embed automatically appends the event ``title`` and the current time as
+    additional fields for more verbose logging information.
     """
 
     embed = discord.Embed(
@@ -54,5 +59,16 @@ def create_log_embed(
     if fields:
         for name, value, inline in fields:
             embed.add_field(name=name, value=value, inline=inline)
+
+    embed.add_field(
+        name="Event",
+        value=title,
+        inline=False,
+    )
+    embed.add_field(
+        name="Time",
+        value=f"<t:{int(embed.timestamp.timestamp())}:F>",
+        inline=False,
+    )
     embed.set_footer(text=f"Logging System | Guild ID: {guild.id if guild else 'N/A'}")
     return embed


### PR DESCRIPTION
## Summary
- log attachments, channel info and more on message edit/delete events
- add logging for channel updates and role create/delete/update
- extend log embeds with event and time fields for more detail

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_688c8522b6308333b50cdb96f9e9c5bb